### PR TITLE
composer require instead of composer update

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,10 +6,10 @@ Models is a service for Laravel 5.7+ that lets you access your model classes mor
 
 ## Installation
 
-Simply add the package to your `composer.json` and run `composer update`.
+You can install the package via composer:
 
 ```
-"addworking/laravel-models": "1.*"
+composer require addworking/laravel-models
 ```
 
 ## Configuration


### PR DESCRIPTION
Better to use composer to add the  package because `composer update` maybe dangerous if we don't want to update the other packages